### PR TITLE
add emregencyWithdraw function for main network test

### DIFF
--- a/contracts/ISwapModule.sol
+++ b/contracts/ISwapModule.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.17;
 
 interface ISwapModule {
-    function getRouterAddress() external returns(address);
+    function getRouterAddress() external view returns(address);
+    function getFactoryAddress() external view returns(address);
 
     function swapExactInput(
         uint256 amountIn,

--- a/contracts/Product.sol
+++ b/contracts/Product.sol
@@ -399,7 +399,7 @@ contract Product is ERC20, IProduct, SwapModule, AutomationCompatibleInterface {
         return shareAmount;
     }
 
-    function emergencyWithdrawForTest() external onlyDac {
+    function emergencyWithdraw() external onlyDac {
         require(!isActive, "Emergency withdrawal is disabled now");
 
         for(uint i=0; i<assets.length; i++){

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -12,11 +12,6 @@ contract Strategy is IStrategy {
     address _dacAddress;
     address _productAddress;
 
-    modifier onlyDac {
-        require(msg.sender == _dacAddress, "No permission");
-        _;
-    }
-
     modifier onlyProduct {
         require(msg.sender == _productAddress, "No permission");
         _;
@@ -49,7 +44,7 @@ contract Strategy is IStrategy {
         return true;
     }
 
-    function withdrawAllToProduct() external onlyDac returns(bool) {
+    function withdrawAllToProduct() external onlyProduct returns(bool) {
         // If product is in activation state, Dac cannot call this method
         require(!IProduct(_productAddress).checkActivation(), "Product is active now");
         SafeERC20.safeTransfer(IERC20(_underlyingAsset), _productAddress, totalAssets());

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -40,7 +40,7 @@ contract Strategy is IStrategy {
     }
 
     function withdrawToProduct(uint256 assetAmount) external override onlyProduct returns(bool) {
-        SafeERC20.safeTransfer(IERC20(_underlyingAsset), _productAddress, assetAmount);
+        if(assetAmount > 0) SafeERC20.safeTransfer(IERC20(_underlyingAsset), _productAddress, assetAmount);
         return true;
     }
 

--- a/contracts/SwapModule.sol
+++ b/contracts/SwapModule.sol
@@ -5,25 +5,13 @@ import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
 import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
-import "./ISwapModule.sol";
 
 contract SwapModule {
-    address public factory;
-    IUniswapV2Router02 public router;
+    address public swapFactory;
+    IUniswapV2Router02 public swapRouter;
 
-    function _getPair(address tokenA, address tokenB) internal view returns (IUniswapV2Pair) {
-        IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(factory, tokenA, tokenB));
-        return pair;
-    }
-
-    function _getPairAddress(address tokenA, address tokenB) internal view returns (address) {
-        IUniswapV2Factory factory_ = IUniswapV2Factory(factory);
-        address pair = factory_.getPair(tokenA, tokenB);
-        return pair;
-    }
-
-    function _swapExactInput(uint256 amountIn, address inputToken, address outputToken, address quinoaVault) internal {
-        IUniswapV2Pair pair = _getPair(inputToken, outputToken);
+    function _swapExactInput(uint256 amountIn, address inputToken, address outputToken, address to) internal {
+        IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(swapFactory, inputToken, outputToken));
         (uint reserves0, uint reserves1,) = pair.getReserves();
         (uint inputTokenReserve, uint outputTokenReserve) = inputToken == pair.token0() ? (reserves0, reserves1) : (reserves1, reserves0);
 
@@ -35,7 +23,7 @@ contract SwapModule {
 
         // set slippate to 0.5%
         uint tokenAmountOutMin = amountOut * (1000 - 5) / 1000;
-        router.swapExactTokensForTokens(amountIn, tokenAmountOutMin, path, quinoaVault, block.timestamp);
+        swapRouter.swapExactTokensForTokens(amountIn, tokenAmountOutMin, path, to, block.timestamp);
     }
 
     function _estimateSwapOutputAmount( uint256 amountIn, address inputToken, address outputToken) internal view returns (uint256) { 
@@ -43,7 +31,7 @@ contract SwapModule {
             return 0;
         }
 
-        IUniswapV2Pair pair = _getPair(inputToken, outputToken);
+        IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(swapFactory, inputToken, outputToken));
         (uint reserves0, uint reserves1,) = pair.getReserves();
 
         (uint inputTokenReserve, uint outputTokenReserve) = inputToken == pair.token0() ? (reserves0, reserves1) : (reserves1, reserves0);
@@ -56,8 +44,8 @@ contract SwapModule {
         return amountOut;
     }
 
-    function _swapExactOutput(uint256 amountOut, address inputToken, address outputToken, address quinoaVault) internal {
-        IUniswapV2Pair pair = _getPair(inputToken, outputToken);
+    function _swapExactOutput(uint256 amountOut, address inputToken, address outputToken, address to) internal {
+        IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(swapFactory, inputToken, outputToken));
         (uint reserves0, uint reserves1,) = pair.getReserves();
         (uint inputTokenReserve, uint outputTokenReserve) = inputToken == pair.token0() ? (reserves0, reserves1) : (reserves1, reserves0);
 
@@ -69,7 +57,7 @@ contract SwapModule {
 
         // set slippate to 0.5%
         uint tokenAmountInMax = amountIn * (1000 + 5) / 1000;
-        router.swapTokensForExactTokens(amountOut, tokenAmountInMax, path, quinoaVault, block.timestamp);
+        swapRouter.swapTokensForExactTokens(amountOut, tokenAmountInMax, path, to, block.timestamp);
     }
 
     function _estimateSwapInputAmount( uint256 amountOut, address inputToken, address outputToken) internal view returns (uint256) {
@@ -78,7 +66,7 @@ contract SwapModule {
             return 0;
         }
 
-        IUniswapV2Pair pair = _getPair(inputToken, outputToken);
+        IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(swapFactory, inputToken, outputToken));
         (uint reserves0, uint reserves1,) = pair.getReserves();
         (uint inputTokenReserve, uint outputTokenReserve) = inputToken == pair.token0() ? (reserves0, reserves1) : (reserves1, reserves0);
 

--- a/contracts/UsdPriceModule.sol
+++ b/contracts/UsdPriceModule.sol
@@ -25,7 +25,7 @@ contract UsdPriceModule is IUsdPriceModule, Ownable {
     }
 
     ///@dev returns 8 decimals
-    function getLatestPrice(address _asset) internal view returns(uint256) {
+    function _getLatestPrice(address _asset) internal view returns(uint256) {
         require(priceFeeds[_asset] != address(0), "Unsupported token");
         AggregatorV3Interface priceFeed = AggregatorV3Interface(priceFeeds[_asset]);
         (, int price, , , ) = priceFeed.latestRoundData();
@@ -44,7 +44,7 @@ contract UsdPriceModule is IUsdPriceModule, Ownable {
 
     ///@notice returns 18 decimals
     function getAssetUsdValue(address _asset, uint256 _amount) public view override returns(uint256) {
-        uint256 assetPrice = getLatestPrice(_asset);
+        uint256 assetPrice = _getLatestPrice(_asset);
         uint256 assetDecimals = IERC20Metadata(_asset).decimals();
         if(assetDecimals < 10) { 
             return assetPrice * _amount * (10**(10-assetDecimals));
@@ -58,7 +58,7 @@ contract UsdPriceModule is IUsdPriceModule, Ownable {
     }
 
     function convertAssetBalance(address _asset, uint256 _value) public view override returns(uint256) {
-        uint256 targetPrice = getLatestPrice(_asset); // 8 decimal
+        uint256 targetPrice = _getLatestPrice(_asset); // 8 decimal
         uint256 targetAssetDecimals = IERC20Metadata(_asset).decimals(); 
 
         if(targetAssetDecimals < 10) { 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -20,7 +20,7 @@ const PRODUCT_OPTIMIZER = {
   settings: {
     optimizer: {
       enabled: true,
-      runs: 200
+      runs: 300
     },
   },
 }
@@ -33,6 +33,7 @@ const config: HardhatUserConfig = {
     compilers: [DEFAULT_OPTIMIZER],
     overrides: {
       "contracts/Product.sol": PRODUCT_OPTIMIZER,
+      "contracts/archive/customErrorProduct.sol": PRODUCT_OPTIMIZER
     },
   },
   networks: {

--- a/test/ProductCrowdDepositTest2.ts
+++ b/test/ProductCrowdDepositTest2.ts
@@ -48,17 +48,11 @@ describe("random token deposit & random token withdraw test",async () => {
             let depositBalance = depositBalances[rand];
             let depositValue = await usdPriceModule.getAssetUsdValue(depositAddress, depositBalance);
 
-            console.log("deposit: ", i, "deposit Address: ", depositAddress);
-
             await utils.setWhitelists([signers[i]], whitelistRegistry, product.address);
-            console.log("whitelist setting success");
 
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
-            console.log("Approve success: ", await depositContract.allowance(signers[i].address, product.address));
             
-            console.log("deposit balance: ", depositBalance, "user balance: ", await depositContract.balanceOf(signers[i].address));
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
-            console.log("deposit success");
 
             expect(await product.balanceOf(signers[i].address)).equal(depositValue);
 

--- a/test/ProductEmergencyWithdrawTest.ts
+++ b/test/ProductEmergencyWithdrawTest.ts
@@ -1,0 +1,151 @@
+import * as utils from "./utils";
+import { ethers } from "hardhat";
+import { expect, util } from "chai";
+import { parseEther, parseUnits } from "ethers/lib/utils";
+
+describe("emergency withdraw test",async () => {
+    it("withdraw all tokens to dac when emergency situation",async () => {
+        const signers = await ethers.getSigners();
+
+        const {
+            product,
+            wmaticStrategy,
+            wethStrategy,
+            usdcStrategy,
+            ghstStrategy,
+            quickStrategy,
+            usdPriceModule,
+            whitelistRegistry
+        } = await utils.deployContracts(signers[0]);
+        await utils.setUsdPriceModule(signers[0], usdPriceModule);
+        await utils.setProductWithAllStrategy(signers[0], product, wmaticStrategy, wethStrategy, ghstStrategy, quickStrategy, usdcStrategy);
+
+        const {
+            wMaticContract,
+            wEthContract,
+            usdcContract,
+            ghstContract,
+            quickContract
+        } = await utils.distributionTokens(signers);
+        await utils.activateProduct(signers[0], product, wMaticContract);
+        
+        let dacInitialDepositValue = await usdPriceModule.getAssetUsdValue(utils.wmaticAddress, parseEther("200"));
+        let productInitialShareBalance = await product.totalSupply();
+        let productInitialPortfolioValue = await product.portfolioValue();
+        let productInitialWmaticBalance = await product.assetBalance(utils.wmaticAddress);
+        expect(dacInitialDepositValue).equal(productInitialPortfolioValue);
+
+        // Deposit logic
+        const assetChoices = [utils.wmaticAddress, utils.wethAddress, utils.usdcAddress];
+        const assetContracts = [wMaticContract, wEthContract, usdcContract];
+        
+        let cnt = [10, 10, 10]
+        let assetChoices_deposit = [utils.wmaticAddress];
+        let assetContracts_deposit = [wMaticContract];
+        let assetValue_deposit = ["0"];
+
+        for(let i=0; i<30; i++) {
+            let rand = Math.floor(Math.random() * 3);
+            while(cnt[rand] == 0) {
+                rand = Math.floor(Math.random() * 3);
+            }
+            
+            assetChoices_deposit.push(assetChoices[rand]);
+            assetContracts_deposit.push(assetContracts[rand]);
+            cnt[rand] -= 1;
+
+            rand = Math.floor(Math.random() * (30*(10**18))) + 20*(10**18);
+            assetValue_deposit.push(rand.toString());
+        }
+
+        // deposit
+        for (let i=1; i<31; i++){
+            let depositAddress = assetChoices_deposit[i];
+            let depositContract = assetContracts_deposit[i];
+            let depositBalance = await usdPriceModule.convertAssetBalance(depositAddress, assetValue_deposit[i]);
+
+            await utils.delay(50);
+            await utils.setWhitelists([signers[i]], whitelistRegistry, product.address);
+            await depositContract.connect(signers[i]).approve(product.address, depositBalance);
+            await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
+
+        }
+
+        console.log("--------------------------------------------------------------");
+        console.log("before rebalance - product status");
+        console.log("product wmatic balance: ", (await product.assetBalance(utils.wmaticAddress)).toString(), (await wmaticStrategy.totalAssets()).toString());
+        console.log("product weth balance: ", (await product.assetBalance(utils.wethAddress)).toString(), (await wethStrategy.totalAssets()).toString());
+        console.log("product usdc balance: ", (await product.assetBalance(utils.usdcAddress)).toString(), (await usdcStrategy.totalAssets()).toString());
+        console.log("product ghst balance: ", (await product.assetBalance(utils.ghstAddress)).toString(), (await ghstStrategy.totalAssets()).toString());
+        console.log("product quick balance: ", (await product.assetBalance(utils.quickAddress)).toString(), (await quickStrategy.totalAssets()).toString());
+        console.log("product portfolio value: ", (await product.portfolioValue()).toString());
+        console.log("--------------------------------------------------------------");
+        // rebalance
+        await (await product.rebalance()).wait();
+        console.log("reblanace success");
+        console.log("--------------------------------------------------------------");
+        console.log("after rebalance - product status");
+        console.log("product wmatic balance: ", (await product.assetBalance(utils.wmaticAddress)).toString(), (await wmaticStrategy.totalAssets()).toString());
+        console.log("product weth balance: ", (await product.assetBalance(utils.wethAddress)).toString(), (await wethStrategy.totalAssets()).toString());
+        console.log("product usdc balance: ", (await product.assetBalance(utils.usdcAddress)).toString(), (await usdcStrategy.totalAssets()).toString());
+        console.log("product ghst balance: ", (await product.assetBalance(utils.ghstAddress)).toString(), (await ghstStrategy.totalAssets()).toString());
+        console.log("product quick balance: ", (await product.assetBalance(utils.quickAddress)).toString(), (await quickStrategy.totalAssets()).toString());
+        console.log("product portfolio value: ", (await product.portfolioValue()).toString());
+        console.log("--------------------------------------------------------------");
+
+        // deactivate product
+        expect(await product.checkActivation()).equal(true);
+        await (await product.deactivateProduct()).wait();
+        expect(await product.checkActivation()).equal(false);
+        console.log("deactivate product success");
+
+        // withdraw all tokens
+        // wmaticStrategy, wethStrategy, ghstStrategy, quickStrategy, usdcStrategy
+        const beforeWithdrawDacWmaticBalance = await wMaticContract.balanceOf(signers[0].address);
+        const beforeWithdrawDacWethBalance = await wEthContract.balanceOf(signers[0].address);
+        const beforeWithdrawDacUsdcBalance = await usdcContract.balanceOf(signers[0].address);
+        const beforeWithdrawDacGhstBalance = await ghstContract.balanceOf(signers[0].address);
+        const beforeWithdrawDacQuickBalance = await quickContract.balanceOf(signers[0].address);
+        console.log("get dac balances success");
+
+        const beforeWithdrawProductWmaticBalance = await product.assetBalance(utils.wmaticAddress);
+        const beforeWithdrawProductWethBalance = await product.assetBalance(utils.wethAddress);
+        const beforeWithdrawProductUsdcBalance = await product.assetBalance(utils.usdcAddress);
+        const beforeWithdrawProductGhstBalance = await product.assetBalance(utils.ghstAddress);
+        const beforeWithdrawProductQuickBalance = await product.assetBalance(utils.quickAddress);
+        console.log("get product balances success");
+
+        await (await product.emergencyWithdraw()).wait();
+        console.log("emergencyWithdraw success");
+
+        const afterWithdrawDacWmaticBalance = await wMaticContract.balanceOf(signers[0].address);
+        const afterWithdrawDacWethBalance = await wEthContract.balanceOf(signers[0].address);
+        const afterWithdrawDacUsdcBalance = await usdcContract.balanceOf(signers[0].address);
+        const afterWithdrawDacGhstBalance = await ghstContract.balanceOf(signers[0].address);
+        const afterWithdrawDacQuickBalance = await quickContract.balanceOf(signers[0].address);
+        console.log("get dac balances success");
+
+        const afterWithdrawProductWmaticBalance = await product.assetBalance(utils.wmaticAddress);
+        const afterWithdrawProductWethBalance = await product.assetBalance(utils.wethAddress);
+        const afterWithdrawProductUsdcBalance = await product.assetBalance(utils.usdcAddress);
+        const afterWithdrawProductGhstBalance = await product.assetBalance(utils.ghstAddress);
+        const afterWithdrawProductQuickBalance = await product.assetBalance(utils.quickAddress);
+        console.log("get product balances success");
+
+        expect((afterWithdrawProductWmaticBalance).toString()).equal("0");
+        expect((afterWithdrawProductWethBalance).toString()).equal("0");
+        expect((afterWithdrawProductUsdcBalance).toString()).equal("0");
+        expect((afterWithdrawProductGhstBalance).toString()).equal("0");
+        expect((afterWithdrawProductQuickBalance).toString()).equal("0");
+        expect((await product.portfolioValue()).toString()).equal("0");
+        console.log("product balances expect success");
+
+        expect(beforeWithdrawDacWmaticBalance.add(beforeWithdrawProductWmaticBalance)).equal(afterWithdrawDacWmaticBalance);
+        expect(beforeWithdrawDacWethBalance.add(beforeWithdrawProductWethBalance)).equal(afterWithdrawDacWethBalance);
+        expect(beforeWithdrawDacUsdcBalance.add(beforeWithdrawProductUsdcBalance)).equal(afterWithdrawDacUsdcBalance);
+        expect(beforeWithdrawDacGhstBalance.add(beforeWithdrawProductGhstBalance)).equal(afterWithdrawDacGhstBalance);
+        expect(beforeWithdrawDacQuickBalance.add(beforeWithdrawProductQuickBalance)).equal(afterWithdrawDacQuickBalance);
+        console.log("dac balances expect success");
+
+    })
+})

--- a/test/ProductRebalanceTest.ts
+++ b/test/ProductRebalanceTest.ts
@@ -57,7 +57,6 @@ describe("rebalance test",async () => {
 
             expect(await product.balanceOf(signers[i].address)).equal(oneUserShareBalance);
 
-            console.log("signers[", i, "] deposit complete");
         }
 
         let productDepositShareBalance = await product.totalSupply();
@@ -169,15 +168,6 @@ describe("rebalance test",async () => {
             withdrawValues.push(userWithdrawValue);
             withdrawalAddresses.push(withdrawalAddress);
 
-            // console.log("signer[", i, "] withdraw complete");
-            // console.log("signer withdraw token address: ", withdrawalAddress);
-            // console.log("--")
-            // console.log("after withdraw product wmatic balance: ", await product.assetBalance(utils.wmaticAddress));
-            // console.log("after withdraw product weth balance: ", await product.assetBalance(utils.wethAddress));
-            // console.log("after withdraw product usdc balance: ", await product.assetBalance(utils.usdcAddress));
-            // console.log("after withdraw product quick balance: ", await product.assetBalance(utils.quickAddress));
-            // console.log("after withdraw product ghst balance: ", await product.assetBalance(utils.ghstAddress));
-            // console.log("-----------------------------------------------------------------------------------")
         }
 
 

--- a/test/ProductRebalanceTest2.ts
+++ b/test/ProductRebalanceTest2.ts
@@ -61,7 +61,6 @@ describe("rebalance test 2",async () => {
             depositValues_1.push(depositValue);
             depositAddresses_1.push(depositAddress);
 
-            console.log("deposit first", i);
         }
 
         const assetAddresses = [utils.wmaticAddress, utils.wethAddress, utils.usdcAddress, utils.quickAddress, utils.ghstAddress]; 
@@ -102,10 +101,6 @@ describe("rebalance test 2",async () => {
             withdrawValues_1.push(userWithdrawValue);
             withdrawalAddresses_1.push(withdrawalAddress);
 
-            // console.log("signer[", i, "] withdraw complete");
-            // console.log("signer withdraw token address: ", withdrawalAddress);
-            // console.log("-----------------------------------------------------------------------------------")
-            console.log("withdraw first", i);
         }
 
         console.log("\nbefore_rebalance_portfolio_value,",(await product.portfolioValue()).toString());
@@ -141,7 +136,6 @@ describe("rebalance test 2",async () => {
             depositValues_2.push(depositValue);
             depositAddresses_2.push(depositAddress);
 
-            console.log("deposit second", i);
         }
         
         console.log("\nbefore_rebalance_portfolio_value,",(await product.portfolioValue()).toString());
@@ -177,10 +171,6 @@ describe("rebalance test 2",async () => {
             withdrawValues_2.push(userWithdrawValue);
             withdrawalAddresses_2.push(withdrawalAddress);
 
-            // console.log("signer[", i, "] withdraw complete");
-            // console.log("signer withdraw token address: ", withdrawalAddress);
-            // console.log("-----------------------------------------------------------------------------------")
-            console.log("withdraw second", i);
         }
 
         console.log("\nbefore_rebalance_portfolio_value, ",(await product.portfolioValue()).toString());
@@ -207,24 +197,6 @@ describe("rebalance test 2",async () => {
             if(withdrawValues_1[i-2] == undefined) console.log('signer[', i, '] withdraw value: ', withdrawValues_2[i-2]);
             else console.log('signer[', i, '] withdraw value: ', (withdrawValues_1[i-2]).add(withdrawValues_2[i-2]));
         }
-
-        console.log("-------------------------------------------------------------------------------");
-
-        // console.log('final product status is ...');
-        // console.log("before activation portfolio value: ", productInitialPortfolioValue);
-        // console.log("after reblance portfolio value: ", await product.portfolioValue());
-        // console.log('*');
-        // console.log("wmatic value: ", await product.assetValue(utils.wmaticAddress));
-        // console.log("weth value: ", await product.assetValue(utils.wethAddress));
-        // console.log("usdc value: ", await product.assetValue(utils.usdcAddress));
-        // console.log("quick value: ", await product.assetValue(utils.quickAddress));
-        // console.log("ghst value: ", await product.assetValue(utils.ghstAddress));
-        // console.log('*');
-        // console.log("wmatic balance: ", await product.assetBalance(utils.wmaticAddress));
-        // console.log("weth balance: ", await product.assetBalance(utils.wethAddress));
-        // console.log("usdc balance: ", await product.assetBalance(utils.usdcAddress));
-        // console.log("quick balance: ", await product.assetBalance(utils.quickAddress));
-        // console.log("ghst balance: ", await product.assetBalance(utils.ghstAddress));
         
         console.log("-------------------------------------------------------------------------------")
 

--- a/test/ProductWmaticDepositTest.ts
+++ b/test/ProductWmaticDepositTest.ts
@@ -227,16 +227,10 @@ describe('Basic deposit test',async () => {
         swapContract
     } = await utils.distributionTokens([dac, nonDac]);
 
-    // console.log("before deposit, dac wmatic balance: ", await wMaticContract.balanceOf(dac.address));
-    // console.log("before deposit, nonDac wmatic balance: ", await wMaticContract.balanceOf(nonDac.address));
-    // console.log("before total supply: ", await product.totalSupply()); 
-
     let dacDepositValue = await usdPriceModule.getAssetUsdValue(utils.wmaticAddress, ethers.utils.parseEther("200"));
     await wMaticContract.connect(dac).approve(product.address, ethers.utils.parseEther("200"));
     await product.connect(dac).deposit(utils.wmaticAddress, ethers.utils.parseEther("200"), dac.address);
     await product.activateProduct();
-    // console.log("after deposit, dac wmatic balance: ", await wMaticContract.balanceOf(dac.address));
-    // console.log("after dac deposit total supply: ", await product.totalSupply());
 
     expect(product.connect(nonDac).deposit(utils.usdcAddress, parseUnits("50", 6), nonDac.address)).revertedWith("You're not in whitelist");
 
@@ -251,16 +245,6 @@ describe('Basic deposit test',async () => {
     nonDacDepositValue = await usdPriceModule.getAssetUsdValue(utils.wmaticAddress, ethers.utils.parseEther("30"));
     expect(await product.connect(nonDac).callStatic.deposit(utils.wmaticAddress, ethers.utils.parseEther("30"), nonDac.address)).equal(nonDacDepositValue);
     await product.connect(nonDac).deposit(utils.wmaticAddress, ethers.utils.parseEther("30"), nonDac.address);
-    // console.log("after deposit, nonDac wmatic balance: ", await wMaticContract.balanceOf(nonDac.address));
-    // console.log("after nonDac deposit total supply: ", await product.totalSupply());
-    // console.log("after nonDac depoist, balance of sharetoken: ", await product.balanceOf(nonDac.address));
-
-    // console.log("dacDepositValue: ", dacDepositValue);
-    // console.log("nonDacDepositValue: ", nonDacDepositValue);
-    // console.log("portfolioValue: ", await product.portfolioValue());
-    // console.log("sharePrice: ", await product.sharePrice())
-    // console.log("dac maxWithdrawValue: ", await product.maxWithdrawValue(dac.address));
-    // console.log("nonDac maxWithdrawValue", await product.maxWithdrawValue(nonDac.address));
 
     expect(await product.portfolioValue()).equal(dacDepositValue.add(nonDacDepositValue));
     expect(await product.sharePrice()).equal(parseEther("1"));
@@ -400,26 +384,12 @@ describe('decimal 18 in-out',async () => {
     await wMaticContract.connect(nonDac).approve(product.address, ethers.utils.parseEther("100"));
     await product.connect(nonDac).deposit(utils.wmaticAddress, ethers.utils.parseEther("30"), nonDac.address) // wmatic deposit
 
-    console.log("wmatic 30개 value: ", await usdPriceModule.getAssetUsdValue(utils.wmaticAddress, parseEther("30")));
-    console.log("유저의 share token 개수: ", await product.balanceOf(nonDac.address));
-    console.log("product의 total supply: ", await product.totalSupply());
-    console.log("product의 wmatic balance: ", await wMaticContract.balanceOf(product.address));
-    console.log("value -> wmatic asset amouont: ", await product.convertToAssets(utils.wmaticAddress, await product.balanceOf(nonDac.address)));
-    console.log("value -> weth asset amouont: ", await product.convertToAssets(utils.wethAddress, await product.balanceOf(nonDac.address)));
 
     // weth로 전부 withdraw
     await product.connect(nonDac).withdraw(utils.wethAddress, ethers.constants.MaxUint256, nonDac.address, nonDac.address);
-    console.log("nonDac withdraw value: ", await usdPriceModule.getAssetUsdValue(utils.wethAddress, await wEthContract.balanceOf(nonDac.address)));
-    console.log("유저의 share token 개수: ", await product.balanceOf(nonDac.address));
-    console.log("product의 total supply: ", await product.totalSupply());
-    console.log("product의 wmatic balance: ", await wMaticContract.balanceOf(product.address));
-    console.log("유저의 weth 개수: ", await wEthContract.balanceOf(nonDac.address));
     
     await product.deactivateProduct();
     await product.withdraw(utils.wmaticAddress, ethers.constants.MaxUint256, dac.address, dac.address);
-    console.log("product의 total supply: ", await product.totalSupply());
-    console.log("product의 wmatic balance: ", await wMaticContract.balanceOf(product.address));
-    console.log("dac의 wmatic 개수: ", await wMaticContract.balanceOf(dac.address));
   })
 })
 
@@ -455,26 +425,11 @@ describe('wmatic in - quick out',async () => {
     await wMaticContract.connect(nonDac).approve(product.address, ethers.utils.parseEther("100"));
     await product.connect(nonDac).deposit(utils.wmaticAddress, ethers.utils.parseEther("30"), nonDac.address) // wmatic deposit
 
-    console.log("wmatic 30개 value: ", await usdPriceModule.getAssetUsdValue(utils.wmaticAddress, parseEther("30")));
-    console.log("유저의 share token 개수: ", await product.balanceOf(nonDac.address));
-    console.log("product의 total supply: ", await product.totalSupply());
-    console.log("product의 wmatic balance: ", await wMaticContract.balanceOf(product.address));
-    console.log("value -> wmatic asset amouont: ", await product.convertToAssets(utils.wmaticAddress, await product.balanceOf(nonDac.address)));
-    console.log("value -> quick asset amouont: ", await product.convertToAssets(utils.quickAddress, await product.balanceOf(nonDac.address)));
-
     // quick으로 전부 withdraw
     await product.connect(nonDac).withdraw(utils.quickAddress, ethers.constants.MaxUint256, nonDac.address, nonDac.address);
-    console.log("nonDac withdraw value: ", await usdPriceModule.getAssetUsdValue(utils.quickAddress, await quickContract.balanceOf(nonDac.address)));
-    console.log("유저의 share token 개수: ", await product.balanceOf(nonDac.address));
-    console.log("product의 total supply: ", await product.totalSupply());
-    console.log("product의 wmatic balance: ", await wMaticContract.balanceOf(product.address));
-    console.log("유저의 quick 개수: ", await quickContract.balanceOf(nonDac.address));
     
     await product.deactivateProduct();
     await product.withdraw(utils.wmaticAddress, ethers.constants.MaxUint256, dac.address, dac.address);
-    console.log("product의 total supply: ", await product.totalSupply());
-    console.log("product의 wmatic balance: ", await wMaticContract.balanceOf(product.address));
-    console.log("dac의 wmatic 개수: ", await wMaticContract.balanceOf(dac.address));
   })
 })
 

--- a/test/test0.ts
+++ b/test/test0.ts
@@ -75,7 +75,6 @@ describe("rebalance 없는 버전 테스트",async () => {
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
 
-            console.log("deposit, ", i);
         }
 
         let productPortfolioValue_2 = (await product.portfolioValue()).toString();
@@ -116,7 +115,6 @@ describe("rebalance 없는 버전 테스트",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log("withdraw, ", i);
         }
 
 

--- a/test/test1.ts
+++ b/test/test1.ts
@@ -60,8 +60,6 @@ describe("scenario 1",async () => {
             assetValue_deposit.push(rand.toString());
         }
 
-        // console.log(assetChoices_deposit);
-        // console.log(assetValue_deposit);
 
         for (let i=1; i<301; i++){
             let depositAddress = assetChoices_deposit[i];
@@ -73,7 +71,6 @@ describe("scenario 1",async () => {
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
 
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_2 = (await product.portfolioValue()).toString();

--- a/test/test2.ts
+++ b/test/test2.ts
@@ -72,7 +72,6 @@ describe("scenario 2",async () => {
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
 
-            console.log("deposit: ", i);
         }
         
 
@@ -106,7 +105,6 @@ describe("scenario 2",async () => {
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
     
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_4 = (await product.portfolioValue()).toString();
@@ -150,7 +148,6 @@ describe("scenario 2",async () => {
         let user_shareBalance = ["0"];
         let user_estimatedWithdraw = ["0"];
 
-        console.log("USER,TOKEN_PAIR,DEPOSIT,SHARE,WITHDRAW,ESTIMATED");
         for (let i=1; i<151; i++) {
             let withdrawAddress = assetChoices_withdraw[i];
             let withdrawContract = assetContracts_withdraw[i];
@@ -164,7 +161,6 @@ describe("scenario 2",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
 
         let productPortfolioValue_6 = (await product.portfolioValue()).toString();
@@ -200,7 +196,6 @@ describe("scenario 2",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
         
         let productPortfolioValue_8 = (await product.portfolioValue()).toString();

--- a/test/test3.ts
+++ b/test/test3.ts
@@ -78,7 +78,6 @@ describe("scenario 3",async () => {
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
 
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_2 = (await product.portfolioValue()).toString();
@@ -129,8 +128,6 @@ describe("scenario 3",async () => {
         let user_estimatedWithdraw = ["0"];
 
 
-        console.log("USER,TOKEN_PAIR,DEPOSIT,SHARE,WITHDRAW,ESTIMATED");
-        // console.log("signer_num wmatic_balance weth_balance usdc_balance ghst_balance quick_balance total_value");
         for (let i=1; i<301; i++) {
             let withdrawAddress = assetChoices_withdraw[i];
             let withdrawContract = assetContracts_withdraw[i];
@@ -145,7 +142,6 @@ describe("scenario 3",async () => {
 
             assetValue_withdraw.push((userWithdrawValue).toString());
 
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
 
 

--- a/test/test4.ts
+++ b/test/test4.ts
@@ -75,7 +75,6 @@ describe("scenario 4",async () => {
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
 
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_2 = (await product.portfolioValue()).toString();
@@ -116,7 +115,6 @@ describe("scenario 4",async () => {
             await depositContract.connect(signers[i]).approve(product.address, depositBalance);
             await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address);
 
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_4 = (await product.portfolioValue()).toString();
@@ -170,8 +168,6 @@ describe("scenario 4",async () => {
         let user_estimatedWithdraw = ["0"];
 
         // withdraw 1
-        console.log("USER,TOKEN_PAIR,DEPOSIT,SHARE,WITHDRAW,ESTIMATED");
-        
         for (let i=1; i<151; i++) {
             let withdrawAddress = assetChoices_withdraw[i];
             let withdrawContract = assetContracts_withdraw[i];
@@ -185,7 +181,6 @@ describe("scenario 4",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
 
         let productPortfolioValue_6 = (await product.portfolioValue()).toString();
@@ -229,7 +224,6 @@ describe("scenario 4",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
         
         let productPortfolioValue_8 = (await product.portfolioValue()).toString();

--- a/test/test5.ts
+++ b/test/test5.ts
@@ -96,8 +96,6 @@ describe("scenario 5",async () => {
                 await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address); 
                 assetValue_deposit[i] = (await usdPriceModule.getAssetUsdValue(depositAddress, depositBalance.mul(2))).toString();
             }
-
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_2 = (await product.portfolioValue()).toString();
@@ -144,8 +142,6 @@ describe("scenario 5",async () => {
                 await product.connect(signers[i]).deposit(depositAddress, depositBalance, signers[i].address); 
                 assetValue_deposit[i] = (await usdPriceModule.getAssetUsdValue(depositAddress, depositBalance.mul(2))).toString();
             }
-
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_4 = (await product.portfolioValue()).toString();
@@ -183,8 +179,6 @@ describe("scenario 5",async () => {
         let user_estimatedWithdraw = ["0"];
 
         // withdraw 1
-        console.log("USER,TOKEN_PAIR,DEPOSIT,SHARE,WITHDRAW,ESTIMATED");
-        
         for (let i=1; i<151; i++) {
             let withdrawAddress = assetChoices_withdraw[i];
             let withdrawContract = assetContracts_withdraw[i];
@@ -198,7 +192,6 @@ describe("scenario 5",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
 
         let productPortfolioValue_6 = (await product.portfolioValue()).toString();
@@ -242,7 +235,6 @@ describe("scenario 5",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
         
         let productPortfolioValue_8 = (await product.portfolioValue()).toString();

--- a/test/test6.ts
+++ b/test/test6.ts
@@ -92,7 +92,6 @@ describe("scenario 6",async () => {
                 assetValue_deposit[i] = (await usdPriceModule.getAssetUsdValue(depositAddress, depositBalance.mul(2))).toString();
             }
 
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_2 = (await product.portfolioValue()).toString();
@@ -132,7 +131,6 @@ describe("scenario 6",async () => {
                 assetValue_deposit[i] = (await usdPriceModule.getAssetUsdValue(depositAddress, depositBalance.mul(2))).toString();
             }
 
-            console.log("deposit: ", i);
         }
 
         let productPortfolioValue_4 = (await product.portfolioValue()).toString();
@@ -161,8 +159,6 @@ describe("scenario 6",async () => {
         let user_estimatedWithdraw = ["0"];
 
         // withdraw 1
-        console.log("USER,TOKEN_PAIR,DEPOSIT,SHARE,WITHDRAW,ESTIMATED");
-        
         for (let i=1; i<151; i++) {
             let withdrawAddress = assetChoices_withdraw[i];
             let withdrawContract = assetContracts_withdraw[i];
@@ -176,7 +172,6 @@ describe("scenario 6",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
 
         let productPortfolioValue_6 = (await product.portfolioValue()).toString();
@@ -212,7 +207,6 @@ describe("scenario 6",async () => {
             let userWithdrawValue = await usdPriceModule.getAssetUsdValue(withdrawAddress, (await withdrawContract.balanceOf(signers[i].address)).sub(beforeUserBalance));
 
             assetValue_withdraw.push((userWithdrawValue).toString());
-            console.log(i, assetChoices_deposit[i], "-", assetChoices_withdraw[i], user_shareBalance[i],assetValue_deposit[i], assetValue_withdraw[i], user_estimatedWithdraw[i]);
         }
         
         let productPortfolioValue_8 = (await product.portfolioValue()).toString();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,7 +8,7 @@ import usdcAbi from "../abis/usdcABI.json";
 import wEthAbi from "../abis/wEthABI.json";
 import quickAbi from "../abis/quickABI.json";
 import ghstAbi from "../abis/ghstABI.json";
-import quickSwapAbi from "../abis/quickSwapABI.json";
+import quickSwapAbi from "../abis/quickSwapRouterABI.json";
 import { parseEther, parseUnits } from "ethers/lib/utils";
 
 export {wMaticAbi, usdcAbi, wEthAbi, quickAbi, ghstAbi, quickSwapAbi};
@@ -284,7 +284,6 @@ export async function distributionTokens(signers: SignerWithAddress[]) {
         await wMaticContract.connect(val).approve(quickSwapRouter, amountIn);
         await swapContract.connect(val).swapTokensForExactTokens(amountOut, amountIn, path, val.address, Date.now() + 10000*60, {gasLimit: 251234});
 
-        console.log("distribution: ", cnt);
         cnt+=1;
     }
 


### PR DESCRIPTION
## Summary
<!-- 어떤 내용을 개발했는지 요약해서 설명하고, 관련된 이슈 멘션 -->
mainnet 테스트를 위한 emergencyWithdraw function 추가

**Issue Number**
N/A

**PR Type**
<!-- Please check the one that applies to this PR. -->

- [ ] Bugfix
- [x] Feature
- [ ] Design
- [ ] Test code
- [ ] Other... Please describe:

## Description 
<!-- 어떤 내용을 개발했는지 자세히 설명하고 싶은 것들 설명 -->
1. Product.sol → emergencyWithdrawForTest function 추가(for문을 돌면서 assets들을 모두 Dac에게로 transfer)
2. Strategy.sol → 원래 withdrawAllToProduct function은 Dac이 수동으로 호출할 것을 예상하고 만들어진 함수였는데(modifier로 onlyDac 사용) emergencyWithdrawForTest function을 추가하면서 이걸 Product가 호출하는 onlyProduct로 변경

## Code Review Checklist
<!-- 어떤 내용을 중점적으로 code review 해주면 좋겠는지 작성 -->
- [ ] 
- [ ] 
- [ ] 


## Other information
emergencyWithdrawForTest 함수는 test 용으로만 남겨두었으면 좋겠는데(민균 생각),
(추후 유저들이 이 함수를 발견했을 때, 러그 풀이라고 생각할 수 있는 여지가 있는 듯 함)
관련해서는 4명 다같이 논의해 보면 좋을 것 같음
